### PR TITLE
🐛 fix/date-filrtering-customers

### DIFF
--- a/lib/frontend/src/api/core/apiHelpers.ts
+++ b/lib/frontend/src/api/core/apiHelpers.ts
@@ -115,7 +115,8 @@ export const safePaginated = async <T>(
   config: Omit<ApiConfig<PaginatedResponse<T>>, 'safe' | 'fallback'> = {}
 ): Promise<PaginatedResponse<T>> => {
   const fallback: PaginatedResponse<T> = { data: [], total: 0, page, totalPages: 0 }
-  return apiGet<PaginatedResponse<T>>(`${endpoint}?page=${page}`, { 
+  const separator = endpoint.includes('?') ? '&' : '?'
+  return apiGet<PaginatedResponse<T>>(`${endpoint}${separator}page=${page}`, { 
     ...config, 
     safe: true, 
     fallback 
@@ -126,5 +127,6 @@ export const safePaginated = async <T>(
 export const safeGetPaginated = safePaginated
 export const safeGet = safeApiGet
 export const getPaginatedData = <T>(endpoint: string, page: number = 1): Promise<PaginatedResponse<T>> => {
-  return apiGet<PaginatedResponse<T>>(`${endpoint}?page=${page}`)
+  const separator = endpoint.includes('?') ? '&' : '?'
+  return apiGet<PaginatedResponse<T>>(`${endpoint}${separator}page=${page}`)
 }


### PR DESCRIPTION
סינון לקוחות לפי תאריכים - בעיה בפרמטרי URL
הבעיה: כאשר מסננים לקוחות לפי טווח תאריכים, ה-API קיבל כתובות URL פגומות כמו:

זה גרם לכך שהפרמטר [endDate](vscode-file://vscode-app/c:/Users/user1/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) הפך להיות "2025-08-12?page=1" במקום "2025-08-12", מה שגרם לשגיאת מסד נתונים:

הפתרון: תוקנו פונקציות העזר לעימוד ב-[apiHelpers.ts](vscode-file://vscode-app/c:/Users/user1/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) כדי לטפל נכון בפרמטרי query קיימים:

נוספה זיהוי חכם של מפריד: [const separator = endpoint.includes('?') ? '&' : '?'](vscode-file://vscode-app/c:/Users/user1/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
עודכנו שתי הפונקציות [safePaginated](vscode-file://vscode-app/c:/Users/user1/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) ו-[getPaginatedData](vscode-file://vscode-app/c:/Users/user1/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
התוצאה: כתובות URL נבנות כעת נכון:
/controller/customer/dates?startDate=2025-08-03&endDate=2025-08-12&page=1
קבצים שהשתנו:

[apiHelpers.ts](vscode-file://vscode-app/c:/Users/user1/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
